### PR TITLE
fix virustotal.coffee: ERROR TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/src/scripts/virustotal.coffee
+++ b/src/scripts/virustotal.coffee
@@ -94,7 +94,7 @@ module.exports = (robot) ->
               if vt_json.response_code == 1
 
                 summary = """VirusTotal IP Result: #{ip}
-                - Detected Communicating Samples: #{vt_json.detected_communicating_samples.length}
+                - Passive DNS replications:       #{vt_json.resolutions.length}
                 - Detected URLs:                  #{vt_json.detected_urls.length}
                 - Link:                           https://www.virustotal.com/en/ip-address/#{ip}/information/
                 """


### PR DESCRIPTION
I'm receiving this error when I use virustotal ip <ip>. I look at the api docs and perhaps some changes recently, now works fine.

Thanks for these useful scripts.

Salud.
