### PR TITLE
Open DNS dnsdb is not passive

### DIFF
--- a/src/scripts/opendns-umbrella.coffee
+++ b/src/scripts/opendns-umbrella.coffee
@@ -1,5 +1,5 @@
 # Description:
-#   OpenDNS Umbrella Passive DNS & Reputation
+#   OpenDNS Umbrella DNS database & Reputation
 #
 # Dependencies:
 #   None


### PR DESCRIPTION
Open DNS doesn't have a passive DNS system yet.

Unlike passive DNS systems, the database is just an indexed copy of the resolvers logs.

Passive DNS systems are designed to easily and verify traffic from different sources and work in a very different way.
