### PR TITLE
Umbrella pagerank is not Google pagerank

### DIFF
--- a/src/scripts/opendns-umbrella.coffee
+++ b/src/scripts/opendns-umbrella.coffee
@@ -88,7 +88,7 @@ module.exports = (robot) ->
 
               response += "- DGA score of #{opendns_json.dga_score}\," if opendns_json.dga_score is not 0
               response += "- The domain name has #{opendns_json.entropy} entropy\n"
-              response += "- Google Pagerank score of #{opendns_json.pagerank}\n"
+              response += "- Pagerank score of #{opendns_json.pagerank}\n"
               response += "- SecureRank2 score of #{opendns_json.securerank2}\n"
               response += "- Popularity score of #{opendns_json.popularity}\n"
               response += "- It looks like it could be a FastFlux domain\n" if opendns_json.fastflux is true


### PR DESCRIPTION
The "pagerank" value returned here is not Google's PageRank.

The algorithm is similar, but it uses only DNS logs. The ranking might be totally different from Google's pagerank. It is a popularity indicator, but only for DNS names.

A spam web site can have a very high Umbrella PageRank because of the amount of DNS queries observed, yet have a terrible Google PageRank.
